### PR TITLE
glossom-public-base-os-1.0.4

### DIFF
--- a/glossom-public-base-os.json
+++ b/glossom-public-base-os.json
@@ -3,7 +3,7 @@
     "short_description": "glossom-public-base-os",
     "name": "glossom-public-base-os",
     "versions": [{
-        "version": "1.0.3",
+        "version": "1.0.4",
         "status": "active",
         "description_html": "<p>glossom-public-base-os Ubuntu 16.04 x86_64</p>",
         "description_markdown": "glossom-public-base-os Ubuntu 16.04 base x86_64",

--- a/packer-glossom-public-base-os.json
+++ b/packer-glossom-public-base-os.json
@@ -3,7 +3,7 @@
         "type": "amazon-ebs",
         "ssh_pty": true,
         "region": "ap-northeast-1",
-        "source_ami": "ami-afb09dc8",
+        "source_ami": "ami-0417e362",
         "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
         "ssh_timeout": "2m",


### PR DESCRIPTION
・対象AMI: glossom-public-base-os
・release: v1.0.4
・リポジトリの変更：なし
https://github.com/glossom-dev/glossom-public-base-os/blob/master/init.sh#L11
ここのunattended-upgrade実行時に脆弱性対策済みのverのgit（https://launchpad.net/ubuntu/+source/git/1:2.7.4-0ubuntu1.2）がインストールされるので、packerでビルドし直すだけ