### PR TITLE
add idcf ubuntu16.04 base os

### DIFF
--- a/packer-glossom-public-base-os_idcf.json
+++ b/packer-glossom-public-base-os_idcf.json
@@ -1,0 +1,51 @@
+{
+  "variables":{
+    "api_url": "https://compute.jp-east.idcfcloud.com/client/api",
+    "api_key": "{{env `IDCF_API_KEY`}}",
+    "secret_key": "{{env `IDCF_SECRET_KEY`}}",
+    "ip_address_id" : "{{env `IDCF_SOURCE_IP`}}",
+    "ssh_private_key_file" : "{{env `IDCF_SSH_PRIVATE_KEY`}}"
+    },
+    "builders": [ {
+      "type": "cloudstack",
+      "communicator": "ssh",
+      "api_url": "{{user `api_url`}}",
+      "api_key": "{{user `api_key`}}",
+      "secret_key": "{{user `secret_key`}}",
+      "http_get_only": true,
+      "public_ip_address": "{{user `ip_address_id`}}",
+      "use_local_ip_address": false,
+
+      "cidr_list": ["0.0.0.0/0"],
+      "hypervisor": "VMware",
+      "network": "network1",
+      "service_offering": "light.S1",
+      "source_template": "Ubuntu Server 16.04 LTS 64-bit",
+      "zone": "tesla",
+      "keypair": "root",
+      "ssh_private_key_file": "{{user `ssh_private_key_file`}}",
+      "ssh_username": "root",
+      "ssh_timeout": "3m",
+
+      "template_name": "glossom-public-base-os",
+      "template_display_text": "{{isotime \"2006-01-02\"}}",
+      "template_featured": true,
+      "template_password_enabled": false,
+      "template_scalable": true,
+      "template_os": "Ubuntu 14.04 (64-bit)"
+      }
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "init.sh",
+            "destination": "/tmp/init.sh"
+        },
+        {
+            "type": "shell",
+            "inline": [
+                "bash -lc '/tmp/init.sh'"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
IDCF Ubuntu16.04用の設定追加
以下環境変数に設定した上で実行する想定です

- IDCF_API_KEY -> IDCFのAPI KEY
- IDCF_SECRET_KEY -> IDCFのSecret KEY
- IDCF_SOURCE_IP -> IDCFのSource IP
- IDCF_SSH_PRIVATE_KEY -> 初回ssh時に利用するssh key